### PR TITLE
Correct Spelling and Grammar in Introduction section

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -11,7 +11,7 @@ The NuLink technology platform is a fusion of a robust blockchain foundation, ac
 
 At our core, we are committed to safeguarding data privacy. One of our primary objectives is to address the issue of data availability, which is typically divided into two parts. Firstly, we strive to provide consumers with the means to ascertain that the seller has the required data before making a request. Secondly, we aim to establish a mechanism for verifying the authenticity of the data in its encrypted form.
 
-Within the NuLink network, Zero-Knowledge Proof is used to ensure that all functional nodes, including storage nodes, computing nodes, and proxy nodes, have publicly verifiable data processing and computing operations. At the same time, prior to authorizing data access, the data owner is required to present a Zero-Knowledge Proof. This proof verifies that the encrypted data is aligned with its plaintext counterpart, irrespective of the encryption scheme being used. This approach endows NuLink network with enhanced flexibility.
+Within the NuLink network, Zero-Knowledge Proof is used to ensure that all functional nodes, including storage nodes, computing nodes, and proxy nodes, conduct publicly verifiable data processing and computing operations. At the same time, prior to authorizing data access, the data owner is required to present a Zero-Knowledge Proof. This proof verifies that the encrypted data is aligned with its plaintext counterpart, irrespective of the encryption scheme being used. This approach endows NuLink network with enhanced flexibility.
 
 ### Data Sharing
 


### PR DESCRIPTION
Using "conduct" instead of "have" in the sentence "ensure that all functional nodes, including storage nodes, computing nodes, and proxy nodes, conduct publicly verifiable data processing and computing operations" is preferable for several reasons:

Clarity of Action: "Conduct" clearly indicates that the nodes are actively performing the operations. It conveys that these nodes are executing or carrying out the data processing and computing operations, which is more precise than "have."

Verb Appropriateness: "Conduct" is a more suitable verb when describing the performance of processes or activities. It implies direct involvement and management of the operations, whereas "have" suggests possession rather than action.

Active Voice: Using "conduct" puts the sentence in the active voice, making it more direct and dynamic. Active voice is generally preferred in technical writing for its clarity and straightforwardness.

Consistency with Technical Language: In technical contexts, precise verbs are crucial for clear communication. "Conduct" aligns better with the formal and specific nature of technical documentation.

Thus, the correction improves the sentence by making the action clearer and more appropriately aligned with technical writing standards.